### PR TITLE
Adding setup.py and extracting __version__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+from setuptools import setup,find_packages
+
+
+with open('src/hermes/version.py') as fin: exec(fin.read())
+
+setup(
+    name='esri-hermes',
+    version=__version__,
+
+    package_dir={'':'src'},
+    packages=find_packages('src'),
+    include_package_data=True,
+
+    # PyPI MetaData
+    author='achapkowski',
+    author_email='achapkowski@esri.com',
+    description='Collection of Utilities to Read/Write a Dataset\'s Metadata',
+    license='Apache License - 2.0',
+    keywords='esri,arcpy,metadata',
+    url='https://github.com/Esri/hermes',
+    classifiers=(
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'License :: OSI Approved :: Apache Software License',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        ),
+
+    zip_safe=False,
+)

--- a/src/hermes/version.py
+++ b/src/hermes/version.py
@@ -10,6 +10,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from .version import *
-import common
-from .paperwork import Paperwork
+__version__ = "1.1.0"


### PR DESCRIPTION
classifiers, author and author_email at the least need to be looked at.

**version** is put into its own file so that setup.py can read it without having to import the package, reduces overheads and sometimes all of the dependencies of the package aren't available at build time. Basically makes life simpler.
